### PR TITLE
Split CMSIS/CMSIS_DEVICE_L4/STM32_L4_HAL_DRIVER into separate cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_DEBUGGER arm-none-eabi-gdb)
 set(CMAKE_CPPFILT arm-none-eabi-c++filt)
 ##########################################################################
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 ##########################################################################
 add_executable(${MIYO_READER} "")
 ##########################################################################
@@ -42,13 +43,10 @@ target_sources(${MIYO_READER}
 ##########################################################################
 target_compile_features(${MIYO_READER} PUBLIC cxx_std_17)
 ##########################################################################
-target_compile_options(${MIYO_READER} PUBLIC
-  -mcpu=cortex-m4 
-  -mthumb 
-  -mfloat-abi=hard 
-  -mfpu=fpv4-sp-d16
-  -fstack-usage
-  -Wall
+target_link_libraries(${MIYO_READER}
+  miyo-cmsis
+  miyo-cmsis-device-l4
+  miyo-stm32hal
 )
 ##########################################################################
 set_target_properties(

--- a/external/cmsis/CMakeLists.txt
+++ b/external/cmsis/CMakeLists.txt
@@ -1,5 +1,9 @@
 ##########################################################################
 cmake_minimum_required(VERSION 3.16)
 ##########################################################################
-target_include_directories(${MIYO_READER} PRIVATE current/Include)
+set(CMSIS_TARGET "miyo-cmsis")
+##########################################################################
+add_library(${CMSIS_TARGET} INTERFACE)
+##########################################################################
+target_include_directories(${CMSIS_TARGET} INTERFACE current/Include)
 ##########################################################################

--- a/external/cmsis_device_l4/CMakeLists.txt
+++ b/external/cmsis_device_l4/CMakeLists.txt
@@ -1,5 +1,9 @@
 ##########################################################################
 cmake_minimum_required(VERSION 3.16)
 ##########################################################################
-target_include_directories(${MIYO_READER} PRIVATE current/Include)
+set(CMSIS_DEVICE_L4_TARGET "miyo-cmsis-device-l4")
+##########################################################################
+add_library(${CMSIS_DEVICE_L4_TARGET} INTERFACE)
+##########################################################################
+target_include_directories(${CMSIS_DEVICE_L4_TARGET} INTERFACE current/Include)
 ##########################################################################

--- a/external/stm32l4xx_hal_driver/CMakeLists.txt
+++ b/external/stm32l4xx_hal_driver/CMakeLists.txt
@@ -1,13 +1,29 @@
 ##########################################################################
 cmake_minimum_required(VERSION 3.16)
 ##########################################################################
-target_compile_definitions(${MIYO_READER} PRIVATE USE_HAL_DRIVER)
-target_compile_definitions(${MIYO_READER} PRIVATE DEBUG)
-target_compile_definitions(${MIYO_READER} PRIVATE STM32L4S5xx)
+set(STM32L4_HAL_TARGET "miyo-stm32hal")
 ##########################################################################
-target_include_directories(${MIYO_READER} PRIVATE current/Inc)
+add_library(${STM32L4_HAL_TARGET} STATIC "")
 ##########################################################################
-target_sources(${MIYO_READER}
+target_compile_definitions(${STM32L4_HAL_TARGET} PRIVATE USE_HAL_DRIVER)
+target_compile_definitions(${STM32L4_HAL_TARGET} PRIVATE DEBUG)
+target_compile_definitions(${STM32L4_HAL_TARGET} PUBLIC  STM32L4S5xx)
+##########################################################################
+target_include_directories(${STM32L4_HAL_TARGET} PUBLIC  current/Inc)
+target_include_directories(${STM32L4_HAL_TARGET} PRIVATE ../../include)
+target_include_directories(${STM32L4_HAL_TARGET} PRIVATE ../cmsis/current/Include)
+target_include_directories(${STM32L4_HAL_TARGET} PRIVATE ../cmsis_device_l4/current/Include)
+##########################################################################
+target_compile_options(${STM32L4_HAL_TARGET} PUBLIC
+  -mcpu=cortex-m4
+  -mthumb
+  -mfloat-abi=hard
+  -mfpu=fpv4-sp-d16
+  -fstack-usage
+  -Wall
+)
+##########################################################################
+target_sources(${STM32L4_HAL_TARGET}
   PRIVATE
   current/Src/stm32l4xx_hal_dma2d.c
   current/Src/stm32l4xx_hal_irda.c


### PR DESCRIPTION
Both CMSIS libraries become INTERFACE library targets while STM32_L4_HAL_DRIVER is built as a static library. Necessary compiler flags/includes are passed via PUBLIC/PRIVATE target properties.