### PR TITLE
`driver/it8951/getDeviceInfo` - basic IT8951 driver allows to obtain panel device info.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(${MIYO_READER} PUBLIC include)
 target_sources(${MIYO_READER}
   PUBLIC
 
+  src/driver/IT8951/IT8951.cpp
   src/driver/IT8951/IT8951_IO.cpp
 
   src/hal++/Delay.cpp

--- a/include/driver/IT8951/IT8951.h
+++ b/include/driver/IT8951/IT8951.h
@@ -1,0 +1,76 @@
+/**
+ * Miyo - a open software/open hardware ebook - Reader (Firmware)
+ * Copyright (C) 2021 Alexander Entinger, LXRobotics
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef INCLUDE_DRIVER_IT8951_H_
+#define INCLUDE_DRIVER_IT8951_H_
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <driver/IT8951/IT8951_IO.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+namespace miyo::driver::IT8951
+{
+
+/**************************************************************************************
+ * TYPEDEF
+ **************************************************************************************/
+
+typedef struct __attribute__((packed, aligned(4)))
+{
+  uint16_t panel_width;
+  uint16_t panel_height;
+  uint16_t img_buf_address_low;
+  uint16_t img_buf_address_high;
+  uint8_t  fw_version[16];
+  uint8_t  lut_version[16];
+} DeviceInfo;
+static_assert(sizeof(DeviceInfo) == 40);
+
+/**************************************************************************************
+ * CLASS DECLARATION
+ **************************************************************************************/
+
+class IT8951
+{
+public:
+
+  IT8951(IT8951_IO & io);
+
+
+  Error getDeviceInfo(DeviceInfo & dev_info);
+
+
+private:
+
+  IT8951_IO & _io;
+
+};
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+} /* miyo::driver::IT8951 */
+
+#endif /* INCLUDE_DRIVER_IT8951_H_ */

--- a/include/logging/LoggerBase.hpp
+++ b/include/logging/LoggerBase.hpp
@@ -81,7 +81,7 @@ enum class LogLevel
  * CONSTANT
  **************************************************************************************/
 
-static constexpr size_t DEFAULT_LOG_BUFFER_SIZE = 80;
+static constexpr size_t DEFAULT_LOG_BUFFER_SIZE = 160;
 
 /**************************************************************************************
  * CLASS DECLARATION

--- a/src/driver/IT8951/IT8951.cpp
+++ b/src/driver/IT8951/IT8951.cpp
@@ -1,0 +1,66 @@
+/**
+ * Miyo - a open software/open hardware ebook - Reader (Firmware)
+ * Copyright (C) 2021 Alexander Entinger, LXRobotics
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <driver/IT8951/IT8951.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+namespace miyo::driver::IT8951
+{
+
+/**************************************************************************************
+ * DEFINE
+ **************************************************************************************/
+
+#define CHECK_RETURN_VAL(expr) \
+  if (auto ret = (expr); ret != Error::None) { \
+    return ret; \
+  }
+
+/**************************************************************************************
+ * CTOR/DTOR
+ **************************************************************************************/
+
+IT8951::IT8951(IT8951_IO & io)
+: _io{io}
+{
+
+}
+
+/**************************************************************************************
+ * PUBLIC MEMBER FUNCTIONS
+ **************************************************************************************/
+
+Error IT8951::getDeviceInfo(DeviceInfo & dev_info)
+{
+  CHECK_RETURN_VAL(_io.command(Command::USERDEF_GET_DEVICE_SYSTEM_INFO));
+  CHECK_RETURN_VAL(_io.read(reinterpret_cast<uint16_t *>(&dev_info), sizeof(DeviceInfo) / 2));
+  return Error::None;
+}
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+} /* miyo::driver::IT8951 */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include <hal++/DigitalInPin.hpp>
 #include <hal++/DigitalOutPin.hpp>
 
+#include <driver/IT8951/IT8951.h>
 #include <driver/IT8951/IT8951_IO.h>
 
 #include <logging/LoggerBase.hpp>
@@ -142,6 +143,7 @@ miyo::hal::SPI<Spi_1,
 MIYO_LOG_DEVICE_UART_INSTANCE(uart1);
 
 miyo::driver::IT8951::IT8951_IO it8951_io(spi1, it8951_cs_select, it8951_nreset, it8951_host_ready, delay);
+miyo::driver::IT8951::IT8951    it8951   (it8951_io);
 
 /**************************************************************************************
  * MAIN
@@ -170,6 +172,15 @@ int main(void)
     it8951_io.write(0x0208);
     it8951_io.read(data);
     DBG_INFO("LISAR = 0x%04x", data);
+
+    miyo::driver::IT8951::DeviceInfo device_info;
+    it8951.getDeviceInfo(device_info);
+    DBG_INFO("Device Info:\n      Width:  %d px\n      Height: %d px\n      ImageBuffer : 0x%08X\n      FW Version  : %s\n      LUT Version : %s",
+             device_info.panel_width,
+             device_info.panel_height,
+             (static_cast<uint32_t>(device_info.img_buf_address_high) << 16)| device_info.img_buf_address_low,
+             device_info.fw_version,
+             device_info.lut_version);
   }
 }
 


### PR DESCRIPTION
```bash
[I] Device Info:
      Width:  1448 px
      Height: 1072 px
      ImageBuffer : 0x00122480
      FW Version  : SWv_0.6.
      LUT Version : M841_TFAB512
```